### PR TITLE
Fix more than medium

### DIFF
--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -6,13 +6,13 @@ time_to_solve_sec = 350
 description_en = """
 The sentence is given (as a string). Return a list of words that are longer than the average length of all words. If there are no such words, return `["there is no result!"]`.
 
-Words are separated by a whitespace. If there are any punctuation marks, they should be omitted.
+Words are separated by a whitespace. If there are any punctuation marks, they should be omitted (except hyphens).
 """
 
 description_ru = """
 Дано предложение (строкой). Верните список слов, длина которых превышает среднюю длину всех слов. Если таких нет, верните `["there is no result!"]`.
 
-Слова разделены пробелом. Если присутствуют знаки препинания, их не следует учитывать.
+Слова разделены пробелом. Если присутствуют знаки препинания, их не следует учитывать (кроме дефисов).
 """
 
 limits = """
@@ -22,7 +22,7 @@ limits = """
 solution = """
 def solution(sentence: str) -> list:
     import re
-    words = re.findall(r'\w+', sentence)
+    words = re.findall(r'[\w-]+', sentence)
     if not words:
         return ["there is no result!"]
 
@@ -167,3 +167,13 @@ expected  = ["development", "environment"]
 arguments = ["equal equal equal"]
 comment   = "Three equal words"
 expected  = ["there is no result!"]
+
+[[asserts]]
+arguments = ["This is a well-known fact"]
+comment   = "A hyphen inside one of the words"
+expected  = ["well-known"]
+
+[[asserts]]
+arguments = ["red-painted T-shirt"]
+comment   = "A hyphen inside both words"
+expected  = ["red-painted"]

--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -33,7 +33,7 @@ def solution(sentence: str) -> list:
 """
 
 examples = """
-solution("test") == ["there is no result!"]
+solution("hello") == ["there is no result!"]
 solution("This is a sample string.") == ["This", "sample", "string"]
 solution("Some another sample") == ["another", "sample"]
 """
@@ -47,11 +47,6 @@ name = "string"
 name = "array"
 [output_signature.type.nested]
 name = "string"
-
-[[asserts]]
-arguments = ["test"]
-comment   = "Single word"
-expected  = ["there is no result!"]
 
 [[asserts]]
 arguments = ["This is a sample string."]
@@ -77,11 +72,6 @@ expected  = ["programming"]
 arguments = ["a bb ccc dddd"]
 comment   = "Increasing lengths"
 expected  = ["ccc", "dddd"]
-
-[[asserts]]
-arguments = ["short"]
-comment   = "Single word short"
-expected  = ["there is no result!"]
 
 [[asserts]]
 arguments = ["one, two, three, four, five"]
@@ -117,11 +107,6 @@ expected  = ["abc", "abcd"]
 arguments = ["short longer longest"]
 comment   = "Three words increasing"
 expected  = ["longest"]
-
-[[asserts]]
-arguments = ["one"]
-comment   = "Single word one"
-expected  = ["there is no result!"]
 
 [[asserts]]
 arguments = ["testing code quality"]

--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -99,11 +99,6 @@ comment   = "Six words of approximately equal length, the ellipsis at the end"
 expected  = ["Some", "test", "case", "this", "task"]
 
 [[asserts]]
-arguments = ["a ab abc abcd"]
-comment   = "Increasing a sequence"
-expected  = ["abc", "abcd"]
-
-[[asserts]]
 arguments = ["short longer longest"]
 comment   = "Three words increasing"
 expected  = ["longest"]

--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -4,15 +4,15 @@ tags              = ["strings"]
 time_to_solve_sec = 350
 
 description_en = """
-Given a sentence (as string), return an array of words which are longer than the average length of all the words.
+The sentence is given (as a string). Return a list of words that are longer than the average length of all words. If there are no such words, return `["there is no result!"]`.
 
-Words are separated by a whitespace. If there is a trailing period (dot), it should be omitted. If there is no result, return `["there is no result!"]`.
+Words are separated by a whitespace. If there are any punctuation marks, they should be omitted.
 """
 
 description_ru = """
-Дано предложение (строкой), верните массив слов, длина которых превышает среднюю длину всех слов.
+Дано предложение (строкой). Верните список слов, длина которых превышает среднюю длину всех слов. Если таких нет, верните `["there is no result!"]`.
 
-Слова разделены пробелом. Если присутствует точка, её следует пропустить. Если результата нет, верните `["there is no result!"]`.
+Слова разделены пробелом. Если присутствуют знаки препинания, их не следует учитывать.
 """
 
 limits = """
@@ -34,7 +34,7 @@ def solution(sentence: str) -> list:
 
 examples = """
 solution("test") == ["there is no result!"]
-solution("This is a sample string") == ["This", "sample", "string"]
+solution("This is a sample string.") == ["This", "sample", "string"]
 solution("Some another sample") == ["another", "sample"]
 """
 
@@ -54,8 +54,8 @@ comment   = "Single word"
 expected  = ["there is no result!"]
 
 [[asserts]]
-arguments = ["This is a sample string"]
-comment   = "Multiple words, some longer"
+arguments = ["This is a sample string."]
+comment   = "Multiple words, some longer, the period at the end"
 expected  = ["This", "sample", "string"]
 
 [[asserts]]
@@ -84,8 +84,8 @@ comment   = "Single word short"
 expected  = ["there is no result!"]
 
 [[asserts]]
-arguments = ["one two three four five"]
-comment   = "Five words"
+arguments = ["one, two, three, four, five"]
+comment   = "Five comma-separated words"
 expected  = ["three", "four", "five"]
 
 [[asserts]]
@@ -104,9 +104,9 @@ comment   = "Four words"
 expected  = ["python"]
 
 [[asserts]]
-arguments = ["test case for this task"]
-comment   = "Five words equal length"
-expected  = ["test", "case", "this", "task"]
+arguments = ["Some test case for this task..."]
+comment   = "Six words of approximately equal length, the ellipsis at the end"
+expected  = ["Some", "test", "case", "this", "task"]
 
 [[asserts]]
 arguments = ["a ab abc abcd"]
@@ -129,8 +129,8 @@ comment   = "Three words"
 expected  = ["testing", "quality"]
 
 [[asserts]]
-arguments = ["The cat sat on mat"]
-comment   = "Five words"
+arguments = ["The cat sat on mat!"]
+comment   = "Five words, the exclamation mark at the end"
 expected  = ["The", "cat", "sat", "mat"]
 
 [[asserts]]
@@ -139,8 +139,8 @@ comment   = "Three words technical"
 expected  = ["algorithm", "patterns"]
 
 [[asserts]]
-arguments = ["a b c d e f g"]
-comment   = "Seven single letters"
+arguments = ["a, b, c, d, e, f, g"]
+comment   = "Seven comma-separated single letters"
 expected  = ["there is no result!"]
 
 [[asserts]]
@@ -155,7 +155,7 @@ expected  = ["longerword"]
 
 [[asserts]]
 arguments = ["same same same same"]
-comment   = "All same word"
+comment   = "All 'same' word"
 expected  = ["there is no result!"]
 
 [[asserts]]

--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -84,8 +84,8 @@ comment   = "Five words with the"
 expected  = ["quick", "brown", "jumps"]
 
 [[asserts]]
-arguments = ["aa bb cc dd ee"]
-comment   = "All equal length"
+arguments = ["aa bb cc DD EE"]
+comment   = "Five two-letter words"
 expected  = ["there is no result!"]
 
 [[asserts]]
@@ -147,11 +147,6 @@ expected  = ["review", "session"]
 arguments = ["functional programming paradigm"]
 comment   = "Three long words"
 expected  = ["functional", "programming"]
-
-[[asserts]]
-arguments = ["ab cd ef gh ij"]
-comment   = "Five two letter words"
-expected  = ["there is no result!"]
 
 [[asserts]]
 arguments = ["machine learning artificial intelligence"]

--- a/tasks/easy/strings/more_than_medium.toml
+++ b/tasks/easy/strings/more_than_medium.toml
@@ -22,7 +22,7 @@ limits = """
 solution = """
 def solution(sentence: str) -> list:
     import re
-    words = re.findall(r'\\w+', sentence)
+    words = re.findall(r'\w+', sentence)
     if not words:
         return ["there is no result!"]
 


### PR DESCRIPTION
В условии задачи было упоминание точек, что их не нужно учитывать (как знаки препинания). Эталонное решение также учитывало это. Тем не менее, в asserts не было ни одного теста с хоть одной точкой (как и с любым другим знаком препинания). Исправил это: добавил тестов со знаками препинания, а также немного скорректировал решение, добавив в качестве тонкого места два теста на дефисы внутри слов.