### PR TITLE
Fixed single backslashes

### DIFF
--- a/tasks/easy/arrays/matrix_sums_equality.toml
+++ b/tasks/easy/arrays/matrix_sums_equality.toml
@@ -4,16 +4,16 @@ tags              = ["math", "arrays", "matrix"]
 time_to_solve_sec = 250
 
 description_en = """
-Given a $3 \times 3$ matrix of integers, determine if the sum of elements in every row and every column is the same. Return `true` if all sums are equal, otherwise return `false`.
+Given a $3 \\times 3$ matrix of integers, determine if the sum of elements in every row and every column is the same. Return `true` if all sums are equal, otherwise return `false`.
 """
 
 description_ru = """
-Дана матрица $3 \times 3$, состоящая из целых чисел. Проверьте, равны ли суммы чисел во всех строках и всех столбцах. Верните `true`, если все суммы равны, иначе — `false`.
+Дана матрица $3 \\times 3$, состоящая из целых чисел. Проверьте, равны ли суммы чисел во всех строках и всех столбцах. Верните `true`, если все суммы равны, иначе — `false`.
 """
 
 limits = """
-- $\text{len}(m) = 3$
-- $\text{len}(m[i]) = 3$
+- $\\text{len}(m) = 3$
+- $\\text{len}(m[i]) = 3$
 - $-10^6 \\leq m_{i,j} \\leq 10^6$
 """
 

--- a/tasks/easy/greedy/maximum_cars_to_finish.toml
+++ b/tasks/easy/greedy/maximum_cars_to_finish.toml
@@ -21,7 +21,7 @@ description_ru = """
 
 limits = """
 - $1 \\leq x \\leq 10^4$
-- $1 \\leq \text{len}(a) \\leq 10^5$
+- $1 \\leq \\text{len}(a) \\leq 10^5$
 - $0 \\leq a_i \\leq 10^4$
 """
 

--- a/tasks/hard/bitmasks/min_team_combinations.toml
+++ b/tasks/hard/bitmasks/min_team_combinations.toml
@@ -20,9 +20,9 @@ description_ru = """
 """
 
 limits = """
-- $1 \\leq \text{len}(\text{people}) \\leq 15$
-- $0 \\leq \text{people}[i] \\leq 65535$
-- $1 \\leq \text{target\\_skills} \\leq 65535$
+- $1 \\leq \\text{len}(\\text{people}) \\leq 15$
+- $0 \\leq \\text{people}[i] \\leq 65535$
+- $1 \\leq \\text{target\\_skills} \\leq 65535$
 """
 
 solution = """

--- a/tasks/hard/graphs/is_bipartite_graph.toml
+++ b/tasks/hard/graphs/is_bipartite_graph.toml
@@ -20,9 +20,9 @@ description_ru = """
 """
 
 limits = """
-- $1 \\leq \text{len}(\text{graph}) \\leq 100$
-- $0 \\leq \text{graph}[i][j] < \text{len}(\text{graph})$
-- $i \neq \text{graph}[i][j]$
+- $1 \\leq \\text{len}(\\text{graph}) \\leq 100$
+- $0 \\leq \\text{graph}[i][j] < \\text{len}(\\text{graph})$
+- $i \\neq \\text{graph}[i][j]$
 """
 
 solution = """

--- a/tasks/hard/graphs/minimum_tree_cover.toml
+++ b/tasks/hard/graphs/minimum_tree_cover.toml
@@ -17,8 +17,8 @@ description_ru = """
 
 limits = """
 - $1 \\leq n \\leq 10^5$
-- $\text{len}(\text{edges}) = n - 1$
-- $0 \\leq \text{edges}[i][0], \text{edges}[i][1] < n$
+- $\\text{len}(\\text{edges}) = n - 1$
+- $0 \\leq \\text{edges}[i][0], \\text{edges}[i][1] < n$
 """
 
 solution = """

--- a/tasks/medium/games/secret_function.toml
+++ b/tasks/medium/games/secret_function.toml
@@ -10,7 +10,7 @@ Look at the examples, there is a mathematical pattern.
 
 The first number is in range $[1, 7]$, the second in $[0, 8]$.
 
-The secret formula is: $a^b - a \times b$
+The secret formula is: $a^b - a \\times b$
 """
 
 description_ru = """
@@ -20,7 +20,7 @@ description_ru = """
 
 Первое число находится в диапазоне $[1, 7]$, второе в диапазоне $[0, 8]$.
 
-Секретная формула: $a^b - a \times b$
+Секретная формула: $a^b - a \\times b$
 """
 
 limits = """

--- a/tasks/medium/graphs/lowest_common_ancestor.toml
+++ b/tasks/medium/graphs/lowest_common_ancestor.toml
@@ -16,10 +16,10 @@ description_ru = """
 """
 
 limits = """
-- $1 \\leq \text{len}(\text{parent}) \\leq 1000$
-- $-1 \\leq \text{parent}[i] < \text{len}(\text{parent})$
-- $0 \\leq u < \text{len}(\text{parent})$
-- $0 \\leq v < \text{len}(\text{parent})$
+- $1 \\leq \\text{len}(\\text{parent}) \\leq 1000$
+- $-1 \\leq \\text{parent}[i] < \\text{len}(\\text{parent})$
+- $0 \\leq u < \\text{len}(\\text{parent})$
+- $0 \\leq v < \\text{len}(\\text{parent})$
 """
 
 solution = """


### PR DESCRIPTION
В некоторых задачах (например, matrix_sums_equality и secret_function) в разделах description_en, description_ru, limits была допущена ошибка — вместо двух обратных слешей подряд был один. Из-за этого LaTeX отображался не так, как должен.