### PR TITLE
Fix fancy number

### DIFF
--- a/tasks/easy/strings/fancy_number.toml
+++ b/tasks/easy/strings/fancy_number.toml
@@ -50,7 +50,7 @@ solution(9081806) == True
 [[input_signature]]
 argument_name = "number"
 [input_signature.type]
-name = "int"
+name = "integer"
 
 [output_signature.type]
 name = "boolean"

--- a/tasks/easy/strings/fancy_number.toml
+++ b/tasks/easy/strings/fancy_number.toml
@@ -4,19 +4,25 @@ tags              = ["strings", "games"]
 time_to_solve_sec = 300
 
 description_en = """
-Given a number, find whether it is fancy or not.
+Given a number, find whether it is **fancy** or not.
 
-A fancy number is one which when rotated $180$ degrees is the same.
+A number is called **fancy** if it does not change when rotated $180$ degrees.
 
-When rotated: $6$ becomes $9$, $9$ becomes $6$, and $8$, $1$, $0$ remain themselves (do not change).
+With this rotation:
+- $6$ becomes $9$;
+- $9$ becomes $6$;
+- $0$, $1$, $8$ remain themselves;
+- other digits break.
 """
 
 description_ru = """
-Дано число, определите причудливое оно или нет.
+Дано число. Определите, **причудливое** оно или нет.
 
-Число является причудливым, если при развороте на $180$ градусов остается самим собой.
-
-При повороте: $6$ становится $9$, $9$ становится $6$, а $8$, $1$ и $0$ остаются сами собой (не меняются).
+Число называется **причудливым**, если при перевороте на $180$ градусов остается самим собой. При таком перевороте:
+- $6$ становится $9$;
+- $9$ становится $6$;
+- $0$, $1$ и $8$ остаются сами собой;
+- остальные цифры перестают быть цифрами.
 """
 
 limits = """

--- a/tasks/easy/strings/fancy_number.toml
+++ b/tasks/easy/strings/fancy_number.toml
@@ -6,9 +6,7 @@ time_to_solve_sec = 300
 description_en = """
 Given a number, find whether it is **fancy** or not.
 
-A number is called **fancy** if it does not change when rotated $180$ degrees.
-
-With this rotation:
+A number is called **fancy** if it does not change when rotated $180$ degrees. With this rotation:
 - $6$ becomes $9$;
 - $9$ becomes $6$;
 - $0$, $1$, $8$ remain themselves;
@@ -26,168 +24,183 @@ description_ru = """
 """
 
 limits = """
-- $1 \\leq \\text{len}(\\text{num\\_str}) \\leq 10$
-- $\\text{num\\_str} \\in \\{0, 1, 6, 8, 9\\}^*$
+- $-10^9 \\leq \\text{number} \\leq 10^9
 """
 
 solution = """
-def solution(num_str: str) -> bool:
-    mapping = {'0': '0', '1': '1', '6': '9', '8': '8', '9': '6'}
-    rotated = ''
-    for char in reversed(num_str):
-        if char not in mapping:
+def solution(number: int) -> bool:
+    num_str = str(number)
+    mapping = {"0": "0", "1": "1", "6": "9", "8": "8", "9": "6"}
+    rotated = ""
+    for digit in reversed(num_str):
+        if digit not in mapping:
             return False
-        rotated += mapping[char]
+        rotated += mapping[digit]
     return rotated == num_str
 """
 
 examples = """
-solution("96") == True
-solution("916") == True
-solution("996") == False
-solution("9081806") == True
-solution("9088806") == True
+solution(69) == True
+solution(369) == False
+solution(996) == False
+solution(9788) == False
+solution(9081806) == True
 """
 
 [[input_signature]]
-argument_name = "num_str"
+argument_name = "number"
 [input_signature.type]
-name = "string"
+name = "int"
 
 [output_signature.type]
 name = "boolean"
 
 [[asserts]]
-arguments = ["9081806"]
-comment   = "Fancy seven digit"
-expected  = true
+arguments = [-369]
+comment   = "Not fancy"
+expected  = false
 
 [[asserts]]
-arguments = ["916"]
+arguments = [916]
 comment   = "Fancy three digit"
 expected  = true
 
 [[asserts]]
-arguments = ["9088806"]
-comment   = "Fancy with eights"
-expected  = true
+arguments = [926]
+comment   = "Not fancy three digit"
+expected  = false
 
 [[asserts]]
-arguments = ["996"]
+arguments = [996]
 comment   = "Not symmetric"
 expected  = false
 
 [[asserts]]
-arguments = ["96"]
-comment   = "Simple fancy pair"
-expected  = true
-
-[[asserts]]
-arguments = ["0"]
+arguments = [0]
 comment   = "Single zero"
 expected  = true
 
 [[asserts]]
-arguments = ["1"]
+arguments = [1]
 comment   = "Single one"
 expected  = true
 
 [[asserts]]
-arguments = ["8"]
+arguments = [8]
 comment   = "Single eight"
 expected  = true
 
 [[asserts]]
-arguments = ["6"]
+arguments = [6]
 comment   = "Single six not fancy"
 expected  = false
 
 [[asserts]]
-arguments = ["9"]
+arguments = [9]
 comment   = "Single nine not fancy"
 expected  = false
 
 [[asserts]]
-arguments = ["69"]
+arguments = [69]
 comment   = "Sixty-nine fancy"
 expected  = true
 
 [[asserts]]
-arguments = ["88"]
+arguments = [88]
 comment   = "Double eight"
 expected  = true
 
 [[asserts]]
-arguments = ["11"]
-comment   = "Double one"
+arguments = [417]
+comment   = "Bad digits"
+expected  = false
+
+[[asserts]]
+arguments = [404]
+comment   = "Error code"
+expected  = false
+
+[[asserts]]
+arguments = [848]
+comment   = "Eight four eight"
+expected  = false
+
+[[asserts]]
+arguments = [602]
+comment   = "Six zero two"
+expected  = false
+
+[[asserts]]
+arguments = [18581]
+comment   = "Not fancy five digit"
+expected  = false
+
+[[asserts]]
+arguments = [1001]
+comment   = "Palindromic and fancy"
 expected  = true
 
 [[asserts]]
-arguments = ["00"]
-comment   = "Double zero"
-expected  = true
-
-[[asserts]]
-arguments = ["101"]
-comment   = "One zero one"
-expected  = true
-
-[[asserts]]
-arguments = ["808"]
-comment   = "Eight zero eight"
-expected  = true
-
-[[asserts]]
-arguments = ["609"]
-comment   = "Six zero nine"
-expected  = true
-
-[[asserts]]
-arguments = ["1881"]
-comment   = "Fancy four digit"
-expected  = true
-
-[[asserts]]
-arguments = ["1001"]
-comment   = "One zero zero one"
-expected  = true
-
-[[asserts]]
-arguments = ["9696"]
-comment   = "Nine six nine six"
-expected  = true
-
-[[asserts]]
-arguments = ["6889"]
+arguments = [6889]
 comment   = "Fancy six eight eight nine"
 expected  = true
 
 [[asserts]]
-arguments = ["8008"]
-comment   = "Eight zero zero eight"
-expected  = true
-
-[[asserts]]
-arguments = ["9119"]
+arguments = [9119]
 comment   = "Nine one one nine"
 expected  = false
 
 [[asserts]]
-arguments = ["60109"]
-comment   = "Five digit fancy"
-expected  = true
+arguments = [9788]
+comment   = "Random not fancy number"
+expected  = false
 
 [[asserts]]
-arguments = ["90806"]
+arguments = [45154]
+comment   = "Not fancy"
+expected  = false
+
+[[asserts]]
+arguments = [20102]
+comment   = "Five digit not fancy"
+expected  = false
+
+[[asserts]]
+arguments = [96896]
 comment   = "Five digit fancy variant"
 expected  = true
 
 [[asserts]]
-arguments = ["111"]
-comment   = "Triple one"
+arguments = [-111]
+comment   = "Negative with ones"
+expected  = false
+
+[[asserts]]
+arguments = [-888]
+comment   = "Negative with eights"
+expected  = false
+
+[[asserts]]
+arguments = [9081806]
+comment   = "Fancy seven digit"
 expected  = true
 
 [[asserts]]
-arguments = ["888"]
-comment   = "Triple eight"
+arguments = [9162916]
+comment   = "Not fancy seven digit"
+expected  = false
+
+[[asserts]]
+arguments = [9088806]
+comment   = "Fancy with eights"
 expected  = true
+
+[[asserts]]
+arguments = [96966969]
+comment   = "Palindromic but not fancy"
+expected  = false
+
+[[asserts]]
+arguments = [-600080009]
+comment   = "Long negative number"
+expected  = false


### PR DESCRIPTION
Добавил в тесты числа с цифрами 2, 3, 4, 5, 7 и отрицательные (эталонное решение проверяло отсутствие других цифр, в то время как в тестах не было ни одной проверки на наличие этой проверки). Также изменил тип входа со строкового на целый (всё равно чисел по модулю больше чем 10^9 в тестах нет).