### PR TITLE
fix(tasks): escape KaTeX times symbol in matrix_sums_equality

### DIFF
--- a/tasks/easy/arrays/matrix_sums_equality.toml
+++ b/tasks/easy/arrays/matrix_sums_equality.toml
@@ -4,11 +4,11 @@ tags              = ["math", "arrays", "matrix"]
 time_to_solve_sec = 250
 
 description_en = """
-Given a $3 \times 3$ matrix of integers, determine if the sum of elements in every row and every column is the same. Return `true` if all sums are equal, otherwise return `false`.
+Given a $3 \\times 3$ matrix of integers, determine if the sum of elements in every row and every column is the same. Return `true` if all sums are equal, otherwise return `false`.
 """
 
 description_ru = """
-Дана матрица $3 \times 3$, состоящая из целых чисел. Проверьте, равны ли суммы чисел во всех строках и всех столбцах. Верните `true`, если все суммы равны, иначе — `false`.
+Дана матрица $3 \\times 3$, состоящая из целых чисел. Проверьте, равны ли суммы чисел во всех строках и всех столбцах. Верните `true`, если все суммы равны, иначе — `false`.
 """
 
 limits = """


### PR DESCRIPTION
### Description
Fixed a bug where the matrix dimensions ($3 \times 3$) were rendered incorrectly as `3imes3` due to character escaping issues in the double-quoted TOML string. 

### Changes
- Double-escaped the backslash (`\\times`) in `matrix_sums_equality.toml` descriptions (`description_en` and `description_ru`) so it transfers correctly to the frontend KaTeX renderer.

### Verification
Verified via the local preview app (`pnpm run dev` / `node server.mjs`) — the formula now renders perfectly.

From this
<img width="437" height="320" alt="{E864FA97-8ED1-4882-8BD4-090750BD2245}" src="https://github.com/user-attachments/assets/a6b878b7-0117-4b5c-be70-e421d515ad54" />

To this
<img width="496" height="370" alt="{13253268-04B0-4268-BA20-BC186067981F}" src="https://github.com/user-attachments/assets/8dacf914-d276-4355-93d8-34bb70ebd975" />
